### PR TITLE
Fix/parser option doesnt work with svelte

### DIFF
--- a/index.json
+++ b/index.json
@@ -9,6 +9,5 @@
     "trailingComma": "none",
     "bracketSpacing": true,
     "arrowParens": "avoid",
-    "parser":"babel",
     "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/prettier-config",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "displayName": "TAO Prettier Config",
     "description": "TAO shared prettier configuration",
     "publishConfig": {


### PR DESCRIPTION
Parser option is automatically detected, so it should not be defined. It cases issue with `.svelte` files.

https://prettier.io/docs/en/options.html#parser :
"Prettier automatically infers the parser from the input file path, so you shouldn't have to change this setting."