### PR TITLE
Fix/Svelte formatting

### DIFF
--- a/index.json
+++ b/index.json
@@ -9,5 +9,7 @@
     "trailingComma": "none",
     "bracketSpacing": true,
     "arrowParens": "avoid",
-    "endOfLine": "lf"
+    "endOfLine": "lf",
+    "svelteSortOrder": "options-scripts-styles-markup",
+    "svelteBracketNewLine": false
 }


### PR DESCRIPTION
### Summary

Add code style convention for Svelte files.

### Details

It tooks me some time to figure why we have back and forward changes in Svelte files, despite the fact that we share the same code conventions. This is because the local prettier config is overridden by the common package.

### How to test

Update the dependency with `https://github.com/oat-sa/prettier-config#fix/svelte-formatting`
Change something in a Svelte file and save it.

The position of the blocks should remain as `options-scripts-styles-markup`
The tag ends should not be forced to the next line.