### PR TITLE
fix: use overrides for svelte files

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,15 +1,24 @@
 {
-    "$schema": "http://json.schemastore.org/prettierrc",
-    "printWidth": 120,
-    "tabWidth": 4,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": true,
-    "quoteProps": "as-needed",
-    "trailingComma": "none",
-    "bracketSpacing": true,
-    "arrowParens": "avoid",
-    "endOfLine": "lf",
-    "svelteSortOrder": "options-scripts-styles-markup",
-    "svelteBracketNewLine": false
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "printWidth": 120,
+  "tabWidth": 4,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "bracketSameLine": true,   
+  "overrides": [
+      { 
+        "files": "*.svelte", 
+        "options": { 
+          "plugins": ["prettier-plugin-svelte"],
+          "pluginSearchDirs": ["."], 
+          "svelteSortOrder": "options-styles-markup-scripts" 
+          } 
+        }
+  ]
 }

--- a/index.json
+++ b/index.json
@@ -17,7 +17,7 @@
         "options": { 
           "plugins": ["prettier-plugin-svelte"],
           "pluginSearchDirs": ["."], 
-          "svelteSortOrder": "options-styles-markup-scripts" 
+          "svelteSortOrder": "options-scripts-styles-markup" 
           } 
         }
   ]


### PR DESCRIPTION
This PR uses [`overrides`](https://prettier.io/docs/en/configuration.html#configuration-overrides) to make the svelte specific options to only apply to svelte files.
This way non-svelte projects won't be affected by adding svelte specific options added in v1.0.0 

With svelte files, Prettier 3 will show this warning 
```
[warn] Ignored unknown option { pluginSearchDirs: ["."] }.
```

But it's required for Prettier 2. So when we have all projects on Prettier 3 we can remove the `pluginSearchDirs` option.