### PR TITLE
fix: added svelte parser

### DIFF
--- a/index.json
+++ b/index.json
@@ -10,15 +10,16 @@
   "bracketSpacing": true,
   "arrowParens": "avoid",
   "endOfLine": "lf",
-  "bracketSameLine": true,   
+  "bracketSameLine": true,
   "overrides": [
-      { 
-        "files": "*.svelte", 
-        "options": { 
-          "plugins": ["prettier-plugin-svelte"],
-          "pluginSearchDirs": ["."], 
-          "svelteSortOrder": "options-scripts-styles-markup" 
-          } 
-        }
+    {
+      "files": "*.svelte",
+      "options": {
+        "plugins": ["prettier-plugin-svelte"],
+        "pluginSearchDirs": ["."],
+        "parser": "svelte",
+        "svelteSortOrder": "options-scripts-styles-markup"
+      }
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/prettier-config",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "displayName": "TAO Prettier Config",
   "description": "TAO shared prettier configuration",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/prettier-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "TAO Prettier Config",
   "description": "TAO shared prettier configuration",
   "publishConfig": {


### PR DESCRIPTION
Added missing svelte parser for svelte files. 
```
"parser": "svelte",
```
We forgot to add the svelte parser in v1.0, as per the [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte?tab=readme-ov-file#setup) setup instructions.

I also formatted the index.js file with prettier  ✨

To test this, you can copy the contents of the index.js file into a `.prettierrc` file in one of our projects (you'll need to remove the `prettier` field in the package.json in that folder so it uses your `.prettierrc` file)
