### PR TITLE
feat: compatibility with prettier 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# CHANGELOG
+
+## _2.0.0_
+
+-   **BREAKING**: Removed `"pluginSearchDirs": ["."]` in svelte parsing to [make it more friendly](https://github.com/sveltejs/prettier-plugin-svelte?tab=readme-ov-file#setup) with Prettier 3. This gets rid of this warning when using prettier 3:
+
+```
+[warn] Ignored unknown option { pluginSearchDirs: ["."] }
+```
+
+> Note that if you are using Prettier 2, please use version 1 of this prettier-config package.
+
+## _1.0.2_
+
+-   Added `"parser": "svelte"` for parsing svelte files
+
+## _1.0.1_
+
+-   Use `overrides` for svelte parsing
+
+## _1.0.0_ Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [warn] Ignored unknown option { pluginSearchDirs: ["."] }
 ```
 
-> Note that if you are using Prettier 2, please use version 1 of this prettier-config package.
+> Note that if you are using Prettier 2, please use version 1 of this prettier-config package. Added a note in the README about this.
 
 ## _1.0.2_
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # oat-sa/prettier-config
+
 TAO shared prettier configuration
 
 ## Usage
@@ -16,3 +17,9 @@ $ npm install @oat-sa/prettier-config --save-dev
   // ...
   "prettier": "@oat-sa/prettier-config"
 }
+
+## Prettier versions
+
+- If you are using Prettier 2, use `@oat-sa/prettier-config` version 1.x
+- If you are using Prettier 3, use `@oat-sa/prettier-config` version 2.x
+```

--- a/index.json
+++ b/index.json
@@ -1,25 +1,24 @@
 {
-  "$schema": "http://json.schemastore.org/prettierrc",
-  "printWidth": 120,
-  "tabWidth": 4,
-  "useTabs": false,
-  "semi": true,
-  "singleQuote": true,
-  "quoteProps": "as-needed",
-  "trailingComma": "none",
-  "bracketSpacing": true,
-  "arrowParens": "avoid",
-  "endOfLine": "lf",
-  "bracketSameLine": true,
-  "overrides": [
-    {
-      "files": "*.svelte",
-      "options": {
-        "plugins": ["prettier-plugin-svelte"],
-        "pluginSearchDirs": ["."],
-        "parser": "svelte",
-        "svelteSortOrder": "options-scripts-styles-markup"
-      }
-    }
-  ]
+    "$schema": "http://json.schemastore.org/prettierrc",
+    "printWidth": 120,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "quoteProps": "as-needed",
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf",
+    "bracketSameLine": true,
+    "overrides": [
+        {
+            "files": "*.svelte",
+            "options": {
+                "plugins": ["prettier-plugin-svelte"],
+                "parser": "svelte",
+                "svelteSortOrder": "options-scripts-styles-markup"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
- BREAKING CHANGE: removed pluginSearchDirs option
- Updated README and created CHANGELOG

This PR makes this config compatible with Prettier 3

## Reasoning:
When running Prettier 3 with the current config, we get this warning for every file that is checked: 
```
[warn] Ignored unknown option { pluginSearchDirs: ["."] }
```
So this PR will remove this option, which is not compatible with Prettier 3.

Consumers using Prettier 2 should use version 1.x of this package. Added a note about this in the README.